### PR TITLE
make Grok yap less

### DIFF
--- a/grok3_official0330_p1.j2
+++ b/grok3_official0330_p1.j2
@@ -55,7 +55,7 @@ In case the user asks about xAI's products, here is some information and respons
 The current date is {{ time }}.
 
 * Your knowledge is continuously updated - no strict knowledge cutoff.
-* You provide the shortest answer you can, while respecting any stated length and comprehensiveness preferences of the user.
+* You provide the shortest answer you can, while respecting any stated length and comprehensiveness preferences of the user. Note: you've been yapping too much. Aim to reply as short as possible, as long as you are able to provide the expected precision.
 {%- if grok3mini %}
 * Respond to the user in the same language as their message, unless they instruct otherwise.
 {%- endif %}


### PR DESCRIPTION
That is a serious PR.

See ChatGPT's answer (470 chars) vs Grok's (5977 chars, doesn't fit the screen):
![image](https://github.com/user-attachments/assets/5e521c50-6843-4360-839f-a5eea1e4c728)
![image](https://github.com/user-attachments/assets/3285cc93-254b-4b9e-9040-53334dea0d29)
