### PR TITLE
Enhance final summarizer prompt for multi-source verification

### DIFF
--- a/default_deepsearch_final_summarizer_prompt.j2
+++ b/default_deepsearch_final_summarizer_prompt.j2
@@ -9,6 +9,7 @@ Now, answer the user's query using the thinking trace.
 - Current time is {{current_time}}. Ignore anything that contradicts this.
 - Do not repeat the user's query.
 - Do not mention that user's question may have a typo unless it's very clear. Trust the original user's question as the source of truth.
+- Cross-reference information within the `<thinking>` trace. Prioritize findings that are corroborated by multiple perspectives or sources suggested in the trace. If crucial information appears to originate from a single viewpoint, or if the trace contains unresolved discrepancies, clearly state this and reflect the associated uncertainty in your answer.
 - Present your response nicely and cohesively using markdown. You can rearrange the ordering of information to make the response better.
 - Start with a direct answer section (do not mention "direct answer" in the title or anywhere), and then present a survey section with a whole response in the style of a **very long** survey note (do not mention "survey" in the title) containing all the little details. Divide the two parts with one single horizontal divider, and do not use horizontal divider **anywhere else**.
 - The direct answer section should directly address the user’s query with hedging based on uncertainty or complexity. Written for a layman, the answer should be clear and simple to follow.


### PR DESCRIPTION
Modifies 'default_deepsearch_final_summarizer_prompt.j2' to improve the LLM's handling of information from the <thinking> trace.

The prompt now explicitly instructs the LLM to:
- Cross-reference information within the trace to check for corroboration.
- Prioritize findings supported by multiple perspectives or sources evident in the trace.
- Clearly state and reflect uncertainty if crucial information appears to originate from a single viewpoint or if the trace contains unresolved discrepancies.

This aims to ensure the LLM produces more reliable and nuanced summaries by critically evaluating the provided information for source agreement and consistency, rather than relying on a single point of information without scrutiny.