### PR TITLE
Refine summarizer prompt to prioritize recent information

### DIFF
--- a/default_deepsearch_final_summarizer_prompt.j2
+++ b/default_deepsearch_final_summarizer_prompt.j2
@@ -9,6 +9,7 @@ Now, answer the user's query using the thinking trace.
 - Current time is {{current_time}}. Ignore anything that contradicts this.
 - Do not repeat the user's query.
 - Do not mention that user's question may have a typo unless it's very clear. Trust the original user's question as the source of truth.
+- When selecting information from the `<thinking>` trace, prioritize the most recent relevant findings, especially for topics with ongoing developments or recent discoveries. This preference for recency should be overridden if the user's query explicitly seeks historical context or if the nature of the topic inherently requires older information.
 - Present your response nicely and cohesively using markdown. You can rearrange the ordering of information to make the response better.
 - Start with a direct answer section (do not mention "direct answer" in the title or anywhere), and then present a survey section with a whole response in the style of a **very long** survey note (do not mention "survey" in the title) containing all the little details. Divide the two parts with one single horizontal divider, and do not use horizontal divider **anywhere else**.
 - The direct answer section should directly address the user’s query with hedging based on uncertainty or complexity. Written for a layman, the answer should be clear and simple to follow.


### PR DESCRIPTION
Modifies 'default_deepsearch_final_summarizer_prompt.j2' to instruct the LLM to prioritize the most recent relevant information when processing the <thinking> trace.

This change adds a guideline for the LLM to give precedence to newer data, discoveries, or updates found within the trace, particularly for subjects that are rapidly evolving or have seen recent advancements. The instruction includes a condition to defer to user requests for historical data or when the topic's nature (e.g., a historical event) makes older information more pertinent.

The goal is to ensure that the generated summaries reflect the latest available understanding of a topic, unless specified otherwise by the user or the context of the query.